### PR TITLE
feat: config files for pretrained HF aggregation experiments

### DIFF
--- a/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_noprop_embedding_snli_finetune_config.yaml
+++ b/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_noprop_embedding_snli_finetune_config.yaml
@@ -1,0 +1,75 @@
+text_mode: false
+allow_text_files: false
+model:
+  task_type: entailment
+  task_loader_type: aggregative
+  name: pretrained_noprop
+  model_type: embedding
+  graph:
+    node_feature_dim: 804
+    edge_feature_dim: 70
+    graph_rep_dim: 2048
+    pretrained_transformer:
+      model_name: "sentence-transformers/all-MiniLM-L6-v2"
+      max_nodes: 64
+      use_cls_token: false
+      freeze_transformer: false
+      positional_features:
+      - depth
+      - num_siblings
+      - num_children
+      - num_grandparent_children
+      - subtree_size
+      - parent_num_children
+      - distance_to_leaf
+      - nodes_at_level
+      positional_max_values:
+        depth: 15
+        num_siblings: 10
+        num_children: 10
+        num_grandparent_children: 10
+        subtree_size: 40
+        parent_num_children: 10
+        distance_to_leaf: 10
+        nodes_at_level: 20
+  temperature: 0.05
+  aggregation: attention
+  thresh_low: -0.33
+  thresh_high: 0.33
+data:
+  dataset_type: snli
+  batch_size: 256
+  strict_matching: false
+  min_trees_per_group: 1
+  num_workers_train: 0
+  num_workers_val: 0
+  prefetch_factor: 0
+  max_batches_per_epoch: 600
+  contrastive_mode: false
+  allow_negatives: true
+  allow_neutrals: true
+  allow_positives: true
+  num_workers: 0
+embedding_cache_dir: /home/jlunder/research/TMN_DataGen/embedding_cache5/
+use_gpu: false
+train:
+  learning_rate: 5.0e-06
+  pretrained_lr_scale: 0.1
+  weight_decay: 1.0e-05
+  n_epochs: 100
+  patience: 999
+  gradient_accumulation_steps: 1
+  clip_value: 1.0
+  cleanup_interval: 5
+  base_seed: 42
+  reset_epoch_enabled: true
+  checkpoint_save_frequency: 4
+wandb:
+  project: tree-embedding
+  tags:
+  - finetune
+  - embedding
+  - snli
+  - pretrained_noprop
+  log_interval: 10
+  memory_logging: true

--- a/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_noprop_embedding_snli_primary_config.yaml
+++ b/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_noprop_embedding_snli_primary_config.yaml
@@ -1,0 +1,79 @@
+text_mode: false
+allow_text_files: false
+model:
+  task_type: infonce
+  task_loader_type: aggregative
+  name: pretrained_noprop
+  model_type: embedding
+  graph:
+    node_feature_dim: 804
+    edge_feature_dim: 70
+    graph_rep_dim: 2048
+    pretrained_transformer:
+      model_name: "sentence-transformers/all-MiniLM-L6-v2"
+      max_nodes: 64
+      use_cls_token: false
+      freeze_transformer: false
+      positional_features:
+      - depth
+      - num_siblings
+      - num_children
+      - num_grandparent_children
+      - subtree_size
+      - parent_num_children
+      - distance_to_leaf
+      - nodes_at_level
+      positional_max_values:
+        depth: 15
+        num_siblings: 10
+        num_children: 10
+        num_grandparent_children: 10
+        subtree_size: 40
+        parent_num_children: 10
+        distance_to_leaf: 10
+        nodes_at_level: 20
+  temperature: 0.05
+  aggregation: attention
+  positive_infonce_weight: 0.55
+  inverse_infonce_weight: 0.3
+  midpoint_infonce_weight: 0.15
+  thresh_low: -0.33
+  thresh_high: 0.33
+data:
+  dataset_type: snli
+  batch_size: 256
+  strict_matching: false
+  min_trees_per_group: 1
+  num_workers_train: 0
+  num_workers_val: 0
+  prefetch_factor: 0
+  max_batches_per_epoch: 600
+  contrastive_mode: false
+  allow_negatives: true
+  allow_neutrals: true
+  allow_positives: true
+  num_workers: 0
+embedding_cache_dir: /home/jlunder/research/TMN_DataGen/embedding_cache5/
+use_gpu: false
+train:
+  learning_rate: 1.0e-05
+  pretrained_lr_scale: 0.1
+  weight_decay: 1.0e-05
+  n_epochs: 100
+  patience: 999
+  gradient_accumulation_steps: 1
+  clip_value: 1.0
+  cleanup_interval: 5
+  base_seed: 42
+  reset_epoch_enabled: true
+  checkpoint_save_frequency: 4
+wandb:
+  project: tree-embedding
+  tags:
+  - aggregative
+  - embedding
+  - snli
+  - primary
+  - pretrained_noprop
+  log_interval: 10
+  memory_logging: true

--- a/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_noprop_matching_snli_finetune_config.yaml
+++ b/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_noprop_matching_snli_finetune_config.yaml
@@ -1,0 +1,75 @@
+text_mode: false
+allow_text_files: false
+model:
+  task_type: entailment
+  task_loader_type: aggregative
+  name: pretrained_noprop
+  model_type: matching
+  graph:
+    node_feature_dim: 804
+    edge_feature_dim: 70
+    graph_rep_dim: 2048
+    pretrained_transformer:
+      model_name: "sentence-transformers/all-MiniLM-L6-v2"
+      max_nodes: 64
+      use_cls_token: false
+      freeze_transformer: false
+      positional_features:
+      - depth
+      - num_siblings
+      - num_children
+      - num_grandparent_children
+      - subtree_size
+      - parent_num_children
+      - distance_to_leaf
+      - nodes_at_level
+      positional_max_values:
+        depth: 15
+        num_siblings: 10
+        num_children: 10
+        num_grandparent_children: 10
+        subtree_size: 40
+        parent_num_children: 10
+        distance_to_leaf: 10
+        nodes_at_level: 20
+  temperature: 0.05
+  aggregation: attention
+  thresh_low: -0.33
+  thresh_high: 0.33
+data:
+  dataset_type: snli
+  batch_size: 256
+  strict_matching: false
+  min_trees_per_group: 1
+  num_workers_train: 0
+  num_workers_val: 0
+  prefetch_factor: 0
+  max_batches_per_epoch: 600
+  contrastive_mode: false
+  allow_negatives: true
+  allow_neutrals: true
+  allow_positives: true
+  num_workers: 0
+embedding_cache_dir: /home/jlunder/research/TMN_DataGen/embedding_cache5/
+use_gpu: false
+train:
+  learning_rate: 5.0e-06
+  pretrained_lr_scale: 0.1
+  weight_decay: 1.0e-05
+  n_epochs: 100
+  patience: 999
+  gradient_accumulation_steps: 1
+  clip_value: 1.0
+  cleanup_interval: 5
+  base_seed: 42
+  reset_epoch_enabled: true
+  checkpoint_save_frequency: 4
+wandb:
+  project: tree-matching
+  tags:
+  - finetune
+  - matching
+  - snli
+  - pretrained_noprop
+  log_interval: 10
+  memory_logging: true

--- a/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_noprop_matching_snli_primary_config.yaml
+++ b/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_noprop_matching_snli_primary_config.yaml
@@ -1,0 +1,79 @@
+text_mode: false
+allow_text_files: false
+model:
+  task_type: infonce
+  task_loader_type: aggregative
+  name: pretrained_noprop
+  model_type: matching
+  graph:
+    node_feature_dim: 804
+    edge_feature_dim: 70
+    graph_rep_dim: 2048
+    pretrained_transformer:
+      model_name: "sentence-transformers/all-MiniLM-L6-v2"
+      max_nodes: 64
+      use_cls_token: false
+      freeze_transformer: false
+      positional_features:
+      - depth
+      - num_siblings
+      - num_children
+      - num_grandparent_children
+      - subtree_size
+      - parent_num_children
+      - distance_to_leaf
+      - nodes_at_level
+      positional_max_values:
+        depth: 15
+        num_siblings: 10
+        num_children: 10
+        num_grandparent_children: 10
+        subtree_size: 40
+        parent_num_children: 10
+        distance_to_leaf: 10
+        nodes_at_level: 20
+  temperature: 0.05
+  aggregation: attention
+  positive_infonce_weight: 0.55
+  inverse_infonce_weight: 0.3
+  midpoint_infonce_weight: 0.15
+  thresh_low: -0.33
+  thresh_high: 0.33
+data:
+  dataset_type: snli
+  batch_size: 256
+  strict_matching: false
+  min_trees_per_group: 1
+  num_workers_train: 0
+  num_workers_val: 0
+  prefetch_factor: 0
+  max_batches_per_epoch: 600
+  contrastive_mode: false
+  allow_negatives: true
+  allow_neutrals: true
+  allow_positives: true
+  num_workers: 0
+embedding_cache_dir: /home/jlunder/research/TMN_DataGen/embedding_cache5/
+use_gpu: false
+train:
+  learning_rate: 1.0e-05
+  pretrained_lr_scale: 0.1
+  weight_decay: 1.0e-05
+  n_epochs: 100
+  patience: 999
+  gradient_accumulation_steps: 1
+  clip_value: 1.0
+  cleanup_interval: 5
+  base_seed: 42
+  reset_epoch_enabled: true
+  checkpoint_save_frequency: 4
+wandb:
+  project: tree-matching
+  tags:
+  - aggregative
+  - matching
+  - snli
+  - primary
+  - pretrained_noprop
+  log_interval: 10
+  memory_logging: true

--- a/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_text_embedding_snli_finetune_config.yaml
+++ b/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_text_embedding_snli_finetune_config.yaml
@@ -1,0 +1,53 @@
+text_mode: true
+allow_text_files: false
+model:
+  task_type: entailment
+  task_loader_type: aggregative
+  name: pretrained_text
+  model_type: embedding
+  pretrained:
+    model_name: "sentence-transformers/all-MiniLM-L6-v2"
+    freeze_transformer: false
+  graph:
+    graph_rep_dim: 2048
+  temperature: 0.05
+  aggregation: attention
+  thresh_low: -0.33
+  thresh_high: 0.33
+data:
+  dataset_type: snli
+  batch_size: 256
+  strict_matching: false
+  min_trees_per_group: 1
+  num_workers_train: 0
+  num_workers_val: 0
+  prefetch_factor: 0
+  max_batches_per_epoch: 600
+  contrastive_mode: false
+  allow_negatives: true
+  allow_neutrals: true
+  allow_positives: true
+  num_workers: 0
+embedding_cache_dir: /home/jlunder/research/TMN_DataGen/embedding_cache5/
+use_gpu: false
+train:
+  learning_rate: 5.0e-06
+  pretrained_lr_scale: 0.1
+  weight_decay: 1.0e-05
+  n_epochs: 100
+  patience: 999
+  gradient_accumulation_steps: 1
+  clip_value: 1.0
+  cleanup_interval: 5
+  base_seed: 42
+  reset_epoch_enabled: true
+  checkpoint_save_frequency: 4
+wandb:
+  project: tree-embedding
+  tags:
+  - finetune
+  - embedding
+  - snli
+  - pretrained_text
+  log_interval: 10
+  memory_logging: true

--- a/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_text_embedding_snli_primary_config.yaml
+++ b/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_text_embedding_snli_primary_config.yaml
@@ -1,0 +1,57 @@
+text_mode: true
+allow_text_files: false
+model:
+  task_type: infonce
+  task_loader_type: aggregative
+  name: pretrained_text
+  model_type: embedding
+  pretrained:
+    model_name: "sentence-transformers/all-MiniLM-L6-v2"
+    freeze_transformer: false
+  graph:
+    graph_rep_dim: 2048
+  temperature: 0.05
+  aggregation: attention
+  positive_infonce_weight: 0.55
+  inverse_infonce_weight: 0.3
+  midpoint_infonce_weight: 0.15
+  thresh_low: -0.33
+  thresh_high: 0.33
+data:
+  dataset_type: snli
+  batch_size: 256
+  strict_matching: false
+  min_trees_per_group: 1
+  num_workers_train: 0
+  num_workers_val: 0
+  prefetch_factor: 0
+  max_batches_per_epoch: 600
+  contrastive_mode: false
+  allow_negatives: true
+  allow_neutrals: true
+  allow_positives: true
+  num_workers: 0
+embedding_cache_dir: /home/jlunder/research/TMN_DataGen/embedding_cache5/
+use_gpu: false
+train:
+  learning_rate: 1.0e-05
+  pretrained_lr_scale: 0.1
+  weight_decay: 1.0e-05
+  n_epochs: 100
+  patience: 999
+  gradient_accumulation_steps: 1
+  clip_value: 1.0
+  cleanup_interval: 5
+  base_seed: 42
+  reset_epoch_enabled: true
+  checkpoint_save_frequency: 4
+wandb:
+  project: tree-embedding
+  tags:
+  - aggregative
+  - embedding
+  - snli
+  - primary
+  - pretrained_text
+  log_interval: 10
+  memory_logging: true

--- a/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_text_matching_snli_finetune_config.yaml
+++ b/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_text_matching_snli_finetune_config.yaml
@@ -1,0 +1,53 @@
+text_mode: true
+allow_text_files: false
+model:
+  task_type: entailment
+  task_loader_type: aggregative
+  name: pretrained_text
+  model_type: matching
+  pretrained:
+    model_name: "sentence-transformers/all-MiniLM-L6-v2"
+    freeze_transformer: false
+  graph:
+    graph_rep_dim: 2048
+  temperature: 0.05
+  aggregation: attention
+  thresh_low: -0.33
+  thresh_high: 0.33
+data:
+  dataset_type: snli
+  batch_size: 256
+  strict_matching: false
+  min_trees_per_group: 1
+  num_workers_train: 0
+  num_workers_val: 0
+  prefetch_factor: 0
+  max_batches_per_epoch: 600
+  contrastive_mode: false
+  allow_negatives: true
+  allow_neutrals: true
+  allow_positives: true
+  num_workers: 0
+embedding_cache_dir: /home/jlunder/research/TMN_DataGen/embedding_cache5/
+use_gpu: false
+train:
+  learning_rate: 5.0e-06
+  pretrained_lr_scale: 0.1
+  weight_decay: 1.0e-05
+  n_epochs: 100
+  patience: 999
+  gradient_accumulation_steps: 1
+  clip_value: 1.0
+  cleanup_interval: 5
+  base_seed: 42
+  reset_epoch_enabled: true
+  checkpoint_save_frequency: 4
+wandb:
+  project: tree-matching
+  tags:
+  - finetune
+  - matching
+  - snli
+  - pretrained_text
+  log_interval: 10
+  memory_logging: true

--- a/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_text_matching_snli_primary_config.yaml
+++ b/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_text_matching_snli_primary_config.yaml
@@ -1,0 +1,57 @@
+text_mode: true
+allow_text_files: false
+model:
+  task_type: infonce
+  task_loader_type: aggregative
+  name: pretrained_text
+  model_type: matching
+  pretrained:
+    model_name: "sentence-transformers/all-MiniLM-L6-v2"
+    freeze_transformer: false
+  graph:
+    graph_rep_dim: 2048
+  temperature: 0.05
+  aggregation: attention
+  positive_infonce_weight: 0.55
+  inverse_infonce_weight: 0.3
+  midpoint_infonce_weight: 0.15
+  thresh_low: -0.33
+  thresh_high: 0.33
+data:
+  dataset_type: snli
+  batch_size: 256
+  strict_matching: false
+  min_trees_per_group: 1
+  num_workers_train: 0
+  num_workers_val: 0
+  prefetch_factor: 0
+  max_batches_per_epoch: 600
+  contrastive_mode: false
+  allow_negatives: true
+  allow_neutrals: true
+  allow_positives: true
+  num_workers: 0
+embedding_cache_dir: /home/jlunder/research/TMN_DataGen/embedding_cache5/
+use_gpu: false
+train:
+  learning_rate: 1.0e-05
+  pretrained_lr_scale: 0.1
+  weight_decay: 1.0e-05
+  n_epochs: 100
+  patience: 999
+  gradient_accumulation_steps: 1
+  clip_value: 1.0
+  cleanup_interval: 5
+  base_seed: 42
+  reset_epoch_enabled: true
+  checkpoint_save_frequency: 4
+wandb:
+  project: tree-matching
+  tags:
+  - aggregative
+  - matching
+  - snli
+  - primary
+  - pretrained_text
+  log_interval: 10
+  memory_logging: true

--- a/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_tree_embedding_contrastive_config.yaml
+++ b/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_tree_embedding_contrastive_config.yaml
@@ -1,0 +1,153 @@
+text_mode: false
+allow_text_files: false
+model:
+  task_type: infonce
+  task_loader_type: contrastive
+  name: pretrained_tree_embedding
+  model_type: embedding
+  graph:
+    node_feature_dim: 804
+    edge_feature_dim: 70
+    node_state_dim: 1280
+    edge_state_dim: 512
+    hidden_size_multiplier: 2.0
+    edge_hidden_sizes:
+    - 512
+    - 1024
+    node_hidden_sizes:
+    - 1280
+    - 1280
+    graph_rep_dim: 2048
+    graph_transform_sizes:
+    - 1280
+    - 2048
+    edge_net_init_scale: 0.1
+    reverse_dir_param_different: false
+    use_reverse_direction: true
+    share_prop_params: true
+    n_prop_layers: 5
+    pretrained_transformer:
+      model_name: "sentence-transformers/all-MiniLM-L6-v2"
+      max_nodes: 64
+      use_cls_token: false
+      freeze_transformer: false
+      positional_features:
+      - depth
+      - num_siblings
+      - num_children
+      - num_grandparent_children
+      - subtree_size
+      - parent_num_children
+      - distance_to_leaf
+      - nodes_at_level
+      positional_max_values:
+        depth: 15
+        num_siblings: 10
+        num_children: 10
+        num_grandparent_children: 10
+        subtree_size: 40
+        parent_num_children: 10
+        distance_to_leaf: 10
+        nodes_at_level: 20
+  temperature: 0.05
+data:
+  dataset_type: wikiqs
+  dataset_specs:
+  - wikiqs
+  - amazonqa_single/Electronics
+  - amazonqa_single/Baby
+  - amazonqa_multiple/Baby
+  - amazonqa_multiple/Electronics
+  - amazonqa_single/Home_and_Kitchen
+  - amazonqa_single/Industrial_and_Scientific
+  - amazonqa_single/Sports_and_Outdoors
+  - amazonqa_single/Appliances
+  - amazonqa_single/Arts_Crafts_and_Sewing
+  - amazonqa_single/Automotive
+  - amazonqa_single/Beauty
+  - amazonqa_single/Cell_Phones_and_Accessories
+  - amazonqa_single/Clothing_Shoes_and_Jewelry
+  - amazonqa_single/Grocery_and_Gourmet_Food
+  - amazonqa_single/Health_and_Personal_Care
+  - amazonqa_single/Musical_Instruments
+  - amazonqa_single/Office_Products
+  - amazonqa_single/Patio_Lawn_and_Garden
+  - amazonqa_single/Pet_Supplies
+  - amazonqa_single/Software
+  - amazonqa_single/Tools_and_Home_Improvement
+  - amazonqa_single/Toys_and_Games
+  - amazonqa_single/Video_Games
+  - amazonqa_multiple/Home_and_Kitchen
+  - amazonqa_multiple/Industrial_and_Scientific
+  - amazonqa_multiple/Sports_and_Outdoors
+  - amazonqa_multiple/Appliances
+  - amazonqa_multiple/Arts_Crafts_and_Sewing
+  - amazonqa_multiple/Automotive
+  - amazonqa_multiple/Beauty
+  - amazonqa_multiple/Cell_Phones_and_Accessories
+  - amazonqa_multiple/Clothing_Shoes_and_Jewelry
+  - amazonqa_multiple/Grocery_and_Gourmet_Food
+  - amazonqa_multiple/Health_and_Personal_Care
+  - amazonqa_multiple/Musical_Instruments
+  - amazonqa_multiple/Office_Products
+  - amazonqa_multiple/Patio_Lawn_and_Garden
+  - amazonqa_multiple/Pet_Supplies
+  - amazonqa_multiple/Software
+  - amazonqa_multiple/Tools_and_Home_Improvement
+  - amazonqa_multiple/Toys_and_Games
+  - amazonqa_multiple/Video_Games
+  allow_cross_dataset_negatives: false
+  batch_size: 256
+  strict_matching: false
+  pos_pairs_per_anchor: 3
+  neg_pairs_per_anchor: 10
+  min_groups_per_batch: 8
+  anchors_per_group: 1
+  num_workers: 2
+  positive_pairing_ratio: 1.0
+  ensure_positives_in_batch: true
+  prefetch_factor: 2
+  max_batches_per_epoch: 600
+  max_text_chars: 500
+  use_hard_negative_mining: true
+  hard_negative_mining:
+    negative_sampling_mode: ratio_based
+    max_negatives_per_anchor: 10
+    target_neg_to_pos_ratio: 20
+    sampling_strategy: weighted
+    use_structural_filtering: true
+    structural_features:
+    - name: node_count
+      threshold: 0.3
+      weight: 1.0
+      order: 1
+    - name: max_depth
+      threshold: 0.3
+      weight: 0.8
+      order: 2
+    use_semantic_ranking: true
+    semantic_weight: 2.0
+embedding_cache_dir: /home/jlunder/research/TMN_DataGen/embedding_cache5/
+use_gpu: false
+train:
+  learning_rate: 1.0e-05
+  pretrained_lr_scale: 0.1
+  weight_decay: 1.0e-05
+  n_epochs: 50
+  patience: 999
+  gradient_accumulation_steps: 1
+  clip_value: 1.0
+  cleanup_interval: 5
+  base_seed: 42
+  reset_epoch_enabled: true
+  checkpoint_save_frequency: 4
+wandb:
+  project: tree-embedding-transformer
+  tags:
+  - contrastive
+  - wikiqs
+  - embedding
+  - pretrained_tree
+  - prop_heavy
+  log_interval: 10
+  memory_logging: true

--- a/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_tree_embedding_snli_finetune_config.yaml
+++ b/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_tree_embedding_snli_finetune_config.yaml
@@ -1,0 +1,93 @@
+text_mode: false
+allow_text_files: false
+model:
+  task_type: entailment
+  task_loader_type: aggregative
+  name: pretrained_tree_embedding
+  model_type: embedding
+  graph:
+    node_feature_dim: 804
+    edge_feature_dim: 70
+    node_state_dim: 1280
+    edge_state_dim: 512
+    hidden_size_multiplier: 2.0
+    edge_hidden_sizes:
+    - 512
+    - 1024
+    node_hidden_sizes:
+    - 1280
+    - 1280
+    graph_rep_dim: 2048
+    graph_transform_sizes:
+    - 1280
+    - 2048
+    edge_net_init_scale: 0.1
+    reverse_dir_param_different: false
+    use_reverse_direction: true
+    share_prop_params: true
+    n_prop_layers: 5
+    pretrained_transformer:
+      model_name: "sentence-transformers/all-MiniLM-L6-v2"
+      max_nodes: 64
+      use_cls_token: false
+      freeze_transformer: false
+      positional_features:
+      - depth
+      - num_siblings
+      - num_children
+      - num_grandparent_children
+      - subtree_size
+      - parent_num_children
+      - distance_to_leaf
+      - nodes_at_level
+      positional_max_values:
+        depth: 15
+        num_siblings: 10
+        num_children: 10
+        num_grandparent_children: 10
+        subtree_size: 40
+        parent_num_children: 10
+        distance_to_leaf: 10
+        nodes_at_level: 20
+  temperature: 0.05
+  aggregation: attention
+  thresh_low: -0.33
+  thresh_high: 0.33
+data:
+  dataset_type: snli
+  batch_size: 256
+  strict_matching: false
+  min_trees_per_group: 1
+  num_workers_train: 0
+  num_workers_val: 0
+  prefetch_factor: 0
+  max_batches_per_epoch: 600
+  contrastive_mode: false
+  allow_negatives: true
+  allow_neutrals: true
+  allow_positives: true
+  num_workers: 0
+embedding_cache_dir: /home/jlunder/research/TMN_DataGen/embedding_cache5/
+use_gpu: false
+train:
+  learning_rate: 5.0e-06
+  pretrained_lr_scale: 0.1
+  weight_decay: 1.0e-05
+  n_epochs: 100
+  patience: 999
+  gradient_accumulation_steps: 1
+  clip_value: 1.0
+  cleanup_interval: 5
+  base_seed: 42
+  reset_epoch_enabled: true
+  checkpoint_save_frequency: 4
+wandb:
+  project: tree-embedding-transformer
+  tags:
+  - finetune
+  - embedding
+  - snli
+  - pretrained_tree
+  - prop_heavy
+  log_interval: 10
+  memory_logging: true

--- a/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_tree_embedding_snli_primary_config.yaml
+++ b/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_tree_embedding_snli_primary_config.yaml
@@ -1,0 +1,97 @@
+text_mode: false
+allow_text_files: false
+model:
+  task_type: infonce
+  task_loader_type: aggregative
+  name: pretrained_tree_embedding
+  model_type: embedding
+  graph:
+    node_feature_dim: 804
+    edge_feature_dim: 70
+    node_state_dim: 1280
+    edge_state_dim: 512
+    hidden_size_multiplier: 2.0
+    edge_hidden_sizes:
+    - 512
+    - 1024
+    node_hidden_sizes:
+    - 1280
+    - 1280
+    graph_rep_dim: 2048
+    graph_transform_sizes:
+    - 1280
+    - 2048
+    edge_net_init_scale: 0.1
+    reverse_dir_param_different: false
+    use_reverse_direction: true
+    share_prop_params: true
+    n_prop_layers: 5
+    pretrained_transformer:
+      model_name: "sentence-transformers/all-MiniLM-L6-v2"
+      max_nodes: 64
+      use_cls_token: false
+      freeze_transformer: false
+      positional_features:
+      - depth
+      - num_siblings
+      - num_children
+      - num_grandparent_children
+      - subtree_size
+      - parent_num_children
+      - distance_to_leaf
+      - nodes_at_level
+      positional_max_values:
+        depth: 15
+        num_siblings: 10
+        num_children: 10
+        num_grandparent_children: 10
+        subtree_size: 40
+        parent_num_children: 10
+        distance_to_leaf: 10
+        nodes_at_level: 20
+  temperature: 0.05
+  aggregation: attention
+  positive_infonce_weight: 0.55
+  inverse_infonce_weight: 0.3
+  midpoint_infonce_weight: 0.15
+  thresh_low: -0.33
+  thresh_high: 0.33
+data:
+  dataset_type: snli
+  batch_size: 256
+  strict_matching: false
+  min_trees_per_group: 1
+  num_workers_train: 0
+  num_workers_val: 0
+  prefetch_factor: 0
+  max_batches_per_epoch: 600
+  contrastive_mode: false
+  allow_negatives: true
+  allow_neutrals: true
+  allow_positives: true
+  num_workers: 0
+embedding_cache_dir: /home/jlunder/research/TMN_DataGen/embedding_cache5/
+use_gpu: false
+train:
+  learning_rate: 1.0e-05
+  pretrained_lr_scale: 0.1
+  weight_decay: 1.0e-05
+  n_epochs: 100
+  patience: 999
+  gradient_accumulation_steps: 1
+  clip_value: 1.0
+  cleanup_interval: 5
+  base_seed: 42
+  reset_epoch_enabled: true
+  checkpoint_save_frequency: 4
+wandb:
+  project: tree-embedding-transformer
+  tags:
+  - aggregative
+  - embedding
+  - snli
+  - primary
+  - pretrained_tree
+  - prop_heavy
+  log_interval: 10
+  memory_logging: true

--- a/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_tree_frozen_gnn_embedding_snli_finetune_config.yaml
+++ b/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_tree_frozen_gnn_embedding_snli_finetune_config.yaml
@@ -1,0 +1,96 @@
+text_mode: false
+allow_text_files: false
+model:
+  task_type: entailment
+  task_loader_type: aggregative
+  name: pretrained_tree_embedding
+  model_type: embedding
+  freeze:
+    freeze_propagation: true
+  strict_checkpoint_load: false
+  graph:
+    node_feature_dim: 804
+    edge_feature_dim: 70
+    node_state_dim: 1280
+    edge_state_dim: 512
+    hidden_size_multiplier: 2.0
+    edge_hidden_sizes:
+    - 512
+    - 1024
+    node_hidden_sizes:
+    - 1280
+    - 1280
+    graph_rep_dim: 2048
+    graph_transform_sizes:
+    - 1280
+    - 2048
+    edge_net_init_scale: 0.1
+    reverse_dir_param_different: false
+    use_reverse_direction: true
+    share_prop_params: true
+    n_prop_layers: 5
+    pretrained_transformer:
+      model_name: "sentence-transformers/all-MiniLM-L6-v2"
+      max_nodes: 64
+      use_cls_token: false
+      freeze_transformer: false
+      positional_features:
+      - depth
+      - num_siblings
+      - num_children
+      - num_grandparent_children
+      - subtree_size
+      - parent_num_children
+      - distance_to_leaf
+      - nodes_at_level
+      positional_max_values:
+        depth: 15
+        num_siblings: 10
+        num_children: 10
+        num_grandparent_children: 10
+        subtree_size: 40
+        parent_num_children: 10
+        distance_to_leaf: 10
+        nodes_at_level: 20
+  temperature: 0.05
+  aggregation: attention
+  thresh_low: -0.33
+  thresh_high: 0.33
+data:
+  dataset_type: snli
+  batch_size: 256
+  strict_matching: false
+  min_trees_per_group: 1
+  num_workers_train: 0
+  num_workers_val: 0
+  prefetch_factor: 0
+  max_batches_per_epoch: 600
+  contrastive_mode: false
+  allow_negatives: true
+  allow_neutrals: true
+  allow_positives: true
+  num_workers: 0
+embedding_cache_dir: /home/jlunder/research/TMN_DataGen/embedding_cache5/
+use_gpu: false
+train:
+  learning_rate: 5.0e-06
+  pretrained_lr_scale: 0.1
+  weight_decay: 1.0e-05
+  n_epochs: 100
+  patience: 999
+  gradient_accumulation_steps: 1
+  clip_value: 1.0
+  cleanup_interval: 5
+  base_seed: 42
+  reset_epoch_enabled: true
+  checkpoint_save_frequency: 4
+wandb:
+  project: tree-embedding-transformer
+  tags:
+  - finetune
+  - embedding
+  - snli
+  - pretrained_tree_frozen_gnn
+  - prop_heavy
+  log_interval: 10
+  memory_logging: true

--- a/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_tree_frozen_gnn_embedding_snli_primary_config.yaml
+++ b/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_tree_frozen_gnn_embedding_snli_primary_config.yaml
@@ -1,0 +1,100 @@
+text_mode: false
+allow_text_files: false
+model:
+  task_type: infonce
+  task_loader_type: aggregative
+  name: pretrained_tree_embedding
+  model_type: embedding
+  freeze:
+    freeze_propagation: true
+  strict_checkpoint_load: false
+  graph:
+    node_feature_dim: 804
+    edge_feature_dim: 70
+    node_state_dim: 1280
+    edge_state_dim: 512
+    hidden_size_multiplier: 2.0
+    edge_hidden_sizes:
+    - 512
+    - 1024
+    node_hidden_sizes:
+    - 1280
+    - 1280
+    graph_rep_dim: 2048
+    graph_transform_sizes:
+    - 1280
+    - 2048
+    edge_net_init_scale: 0.1
+    reverse_dir_param_different: false
+    use_reverse_direction: true
+    share_prop_params: true
+    n_prop_layers: 5
+    pretrained_transformer:
+      model_name: "sentence-transformers/all-MiniLM-L6-v2"
+      max_nodes: 64
+      use_cls_token: false
+      freeze_transformer: false
+      positional_features:
+      - depth
+      - num_siblings
+      - num_children
+      - num_grandparent_children
+      - subtree_size
+      - parent_num_children
+      - distance_to_leaf
+      - nodes_at_level
+      positional_max_values:
+        depth: 15
+        num_siblings: 10
+        num_children: 10
+        num_grandparent_children: 10
+        subtree_size: 40
+        parent_num_children: 10
+        distance_to_leaf: 10
+        nodes_at_level: 20
+  temperature: 0.05
+  aggregation: attention
+  positive_infonce_weight: 0.55
+  inverse_infonce_weight: 0.3
+  midpoint_infonce_weight: 0.15
+  thresh_low: -0.33
+  thresh_high: 0.33
+data:
+  dataset_type: snli
+  batch_size: 256
+  strict_matching: false
+  min_trees_per_group: 1
+  num_workers_train: 0
+  num_workers_val: 0
+  prefetch_factor: 0
+  max_batches_per_epoch: 600
+  contrastive_mode: false
+  allow_negatives: true
+  allow_neutrals: true
+  allow_positives: true
+  num_workers: 0
+embedding_cache_dir: /home/jlunder/research/TMN_DataGen/embedding_cache5/
+use_gpu: false
+train:
+  learning_rate: 1.0e-05
+  pretrained_lr_scale: 0.1
+  weight_decay: 1.0e-05
+  n_epochs: 100
+  patience: 999
+  gradient_accumulation_steps: 1
+  clip_value: 1.0
+  cleanup_interval: 5
+  base_seed: 42
+  reset_epoch_enabled: true
+  checkpoint_save_frequency: 4
+wandb:
+  project: tree-embedding-transformer
+  tags:
+  - aggregative
+  - embedding
+  - snli
+  - primary
+  - pretrained_tree_frozen_gnn
+  - prop_heavy
+  log_interval: 10
+  memory_logging: true

--- a/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_tree_frozen_gnn_matching_snli_finetune_config.yaml
+++ b/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_tree_frozen_gnn_matching_snli_finetune_config.yaml
@@ -1,0 +1,96 @@
+text_mode: false
+allow_text_files: false
+model:
+  task_type: entailment
+  task_loader_type: aggregative
+  name: pretrained_tree_matching
+  model_type: matching
+  freeze:
+    freeze_propagation: true
+  strict_checkpoint_load: false
+  graph:
+    node_feature_dim: 804
+    edge_feature_dim: 70
+    node_state_dim: 1280
+    edge_state_dim: 512
+    hidden_size_multiplier: 2.0
+    edge_hidden_sizes:
+    - 512
+    - 1024
+    node_hidden_sizes:
+    - 1280
+    - 1280
+    graph_rep_dim: 2048
+    graph_transform_sizes:
+    - 1280
+    - 2048
+    edge_net_init_scale: 0.1
+    reverse_dir_param_different: false
+    use_reverse_direction: true
+    share_prop_params: true
+    n_prop_layers: 5
+    pretrained_transformer:
+      model_name: "sentence-transformers/all-MiniLM-L6-v2"
+      max_nodes: 64
+      use_cls_token: false
+      freeze_transformer: false
+      positional_features:
+      - depth
+      - num_siblings
+      - num_children
+      - num_grandparent_children
+      - subtree_size
+      - parent_num_children
+      - distance_to_leaf
+      - nodes_at_level
+      positional_max_values:
+        depth: 15
+        num_siblings: 10
+        num_children: 10
+        num_grandparent_children: 10
+        subtree_size: 40
+        parent_num_children: 10
+        distance_to_leaf: 10
+        nodes_at_level: 20
+  temperature: 0.05
+  aggregation: attention
+  thresh_low: -0.33
+  thresh_high: 0.33
+data:
+  dataset_type: snli
+  batch_size: 256
+  strict_matching: false
+  min_trees_per_group: 1
+  num_workers_train: 0
+  num_workers_val: 0
+  prefetch_factor: 0
+  max_batches_per_epoch: 600
+  contrastive_mode: false
+  allow_negatives: true
+  allow_neutrals: true
+  allow_positives: true
+  num_workers: 0
+embedding_cache_dir: /home/jlunder/research/TMN_DataGen/embedding_cache5/
+use_gpu: false
+train:
+  learning_rate: 5.0e-06
+  pretrained_lr_scale: 0.1
+  weight_decay: 1.0e-05
+  n_epochs: 100
+  patience: 999
+  gradient_accumulation_steps: 1
+  clip_value: 1.0
+  cleanup_interval: 5
+  base_seed: 42
+  reset_epoch_enabled: true
+  checkpoint_save_frequency: 4
+wandb:
+  project: tree-matching-transformer
+  tags:
+  - finetune
+  - matching
+  - snli
+  - pretrained_tree_frozen_gnn
+  - prop_heavy
+  log_interval: 10
+  memory_logging: true

--- a/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_tree_frozen_gnn_matching_snli_primary_config.yaml
+++ b/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_tree_frozen_gnn_matching_snli_primary_config.yaml
@@ -1,0 +1,100 @@
+text_mode: false
+allow_text_files: false
+model:
+  task_type: infonce
+  task_loader_type: aggregative
+  name: pretrained_tree_matching
+  model_type: matching
+  freeze:
+    freeze_propagation: true
+  strict_checkpoint_load: false
+  graph:
+    node_feature_dim: 804
+    edge_feature_dim: 70
+    node_state_dim: 1280
+    edge_state_dim: 512
+    hidden_size_multiplier: 2.0
+    edge_hidden_sizes:
+    - 512
+    - 1024
+    node_hidden_sizes:
+    - 1280
+    - 1280
+    graph_rep_dim: 2048
+    graph_transform_sizes:
+    - 1280
+    - 2048
+    edge_net_init_scale: 0.1
+    reverse_dir_param_different: false
+    use_reverse_direction: true
+    share_prop_params: true
+    n_prop_layers: 5
+    pretrained_transformer:
+      model_name: "sentence-transformers/all-MiniLM-L6-v2"
+      max_nodes: 64
+      use_cls_token: false
+      freeze_transformer: false
+      positional_features:
+      - depth
+      - num_siblings
+      - num_children
+      - num_grandparent_children
+      - subtree_size
+      - parent_num_children
+      - distance_to_leaf
+      - nodes_at_level
+      positional_max_values:
+        depth: 15
+        num_siblings: 10
+        num_children: 10
+        num_grandparent_children: 10
+        subtree_size: 40
+        parent_num_children: 10
+        distance_to_leaf: 10
+        nodes_at_level: 20
+  temperature: 0.05
+  aggregation: attention
+  positive_infonce_weight: 0.55
+  inverse_infonce_weight: 0.3
+  midpoint_infonce_weight: 0.15
+  thresh_low: -0.33
+  thresh_high: 0.33
+data:
+  dataset_type: snli
+  batch_size: 256
+  strict_matching: false
+  min_trees_per_group: 1
+  num_workers_train: 0
+  num_workers_val: 0
+  prefetch_factor: 0
+  max_batches_per_epoch: 600
+  contrastive_mode: false
+  allow_negatives: true
+  allow_neutrals: true
+  allow_positives: true
+  num_workers: 0
+embedding_cache_dir: /home/jlunder/research/TMN_DataGen/embedding_cache5/
+use_gpu: false
+train:
+  learning_rate: 1.0e-05
+  pretrained_lr_scale: 0.1
+  weight_decay: 1.0e-05
+  n_epochs: 100
+  patience: 999
+  gradient_accumulation_steps: 1
+  clip_value: 1.0
+  cleanup_interval: 5
+  base_seed: 42
+  reset_epoch_enabled: true
+  checkpoint_save_frequency: 4
+wandb:
+  project: tree-matching-transformer
+  tags:
+  - aggregative
+  - matching
+  - snli
+  - primary
+  - pretrained_tree_frozen_gnn
+  - prop_heavy
+  log_interval: 10
+  memory_logging: true

--- a/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_tree_frozen_xfmr_embedding_contrastive_config.yaml
+++ b/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_tree_frozen_xfmr_embedding_contrastive_config.yaml
@@ -1,0 +1,155 @@
+text_mode: false
+allow_text_files: false
+model:
+  task_type: infonce
+  task_loader_type: contrastive
+  name: pretrained_tree_embedding
+  model_type: embedding
+  freeze:
+    freeze_transformer: true
+  graph:
+    node_feature_dim: 804
+    edge_feature_dim: 70
+    node_state_dim: 1280
+    edge_state_dim: 512
+    hidden_size_multiplier: 2.0
+    edge_hidden_sizes:
+    - 512
+    - 1024
+    node_hidden_sizes:
+    - 1280
+    - 1280
+    graph_rep_dim: 2048
+    graph_transform_sizes:
+    - 1280
+    - 2048
+    edge_net_init_scale: 0.1
+    reverse_dir_param_different: false
+    use_reverse_direction: true
+    share_prop_params: true
+    n_prop_layers: 5
+    pretrained_transformer:
+      model_name: "sentence-transformers/all-MiniLM-L6-v2"
+      max_nodes: 64
+      use_cls_token: false
+      freeze_transformer: true
+      positional_features:
+      - depth
+      - num_siblings
+      - num_children
+      - num_grandparent_children
+      - subtree_size
+      - parent_num_children
+      - distance_to_leaf
+      - nodes_at_level
+      positional_max_values:
+        depth: 15
+        num_siblings: 10
+        num_children: 10
+        num_grandparent_children: 10
+        subtree_size: 40
+        parent_num_children: 10
+        distance_to_leaf: 10
+        nodes_at_level: 20
+  temperature: 0.05
+data:
+  dataset_type: wikiqs
+  dataset_specs:
+  - wikiqs
+  - amazonqa_single/Electronics
+  - amazonqa_single/Baby
+  - amazonqa_multiple/Baby
+  - amazonqa_multiple/Electronics
+  - amazonqa_single/Home_and_Kitchen
+  - amazonqa_single/Industrial_and_Scientific
+  - amazonqa_single/Sports_and_Outdoors
+  - amazonqa_single/Appliances
+  - amazonqa_single/Arts_Crafts_and_Sewing
+  - amazonqa_single/Automotive
+  - amazonqa_single/Beauty
+  - amazonqa_single/Cell_Phones_and_Accessories
+  - amazonqa_single/Clothing_Shoes_and_Jewelry
+  - amazonqa_single/Grocery_and_Gourmet_Food
+  - amazonqa_single/Health_and_Personal_Care
+  - amazonqa_single/Musical_Instruments
+  - amazonqa_single/Office_Products
+  - amazonqa_single/Patio_Lawn_and_Garden
+  - amazonqa_single/Pet_Supplies
+  - amazonqa_single/Software
+  - amazonqa_single/Tools_and_Home_Improvement
+  - amazonqa_single/Toys_and_Games
+  - amazonqa_single/Video_Games
+  - amazonqa_multiple/Home_and_Kitchen
+  - amazonqa_multiple/Industrial_and_Scientific
+  - amazonqa_multiple/Sports_and_Outdoors
+  - amazonqa_multiple/Appliances
+  - amazonqa_multiple/Arts_Crafts_and_Sewing
+  - amazonqa_multiple/Automotive
+  - amazonqa_multiple/Beauty
+  - amazonqa_multiple/Cell_Phones_and_Accessories
+  - amazonqa_multiple/Clothing_Shoes_and_Jewelry
+  - amazonqa_multiple/Grocery_and_Gourmet_Food
+  - amazonqa_multiple/Health_and_Personal_Care
+  - amazonqa_multiple/Musical_Instruments
+  - amazonqa_multiple/Office_Products
+  - amazonqa_multiple/Patio_Lawn_and_Garden
+  - amazonqa_multiple/Pet_Supplies
+  - amazonqa_multiple/Software
+  - amazonqa_multiple/Tools_and_Home_Improvement
+  - amazonqa_multiple/Toys_and_Games
+  - amazonqa_multiple/Video_Games
+  allow_cross_dataset_negatives: false
+  batch_size: 256
+  strict_matching: false
+  pos_pairs_per_anchor: 3
+  neg_pairs_per_anchor: 10
+  min_groups_per_batch: 8
+  anchors_per_group: 1
+  num_workers: 2
+  positive_pairing_ratio: 1.0
+  ensure_positives_in_batch: true
+  prefetch_factor: 2
+  max_batches_per_epoch: 600
+  max_text_chars: 500
+  use_hard_negative_mining: true
+  hard_negative_mining:
+    negative_sampling_mode: ratio_based
+    max_negatives_per_anchor: 10
+    target_neg_to_pos_ratio: 20
+    sampling_strategy: weighted
+    use_structural_filtering: true
+    structural_features:
+    - name: node_count
+      threshold: 0.3
+      weight: 1.0
+      order: 1
+    - name: max_depth
+      threshold: 0.3
+      weight: 0.8
+      order: 2
+    use_semantic_ranking: true
+    semantic_weight: 2.0
+embedding_cache_dir: /home/jlunder/research/TMN_DataGen/embedding_cache5/
+use_gpu: false
+train:
+  learning_rate: 1.0e-05
+  pretrained_lr_scale: 0.1
+  weight_decay: 1.0e-05
+  n_epochs: 50
+  patience: 999
+  gradient_accumulation_steps: 1
+  clip_value: 1.0
+  cleanup_interval: 5
+  base_seed: 42
+  reset_epoch_enabled: true
+  checkpoint_save_frequency: 4
+wandb:
+  project: tree-embedding-transformer
+  tags:
+  - contrastive
+  - wikiqs
+  - embedding
+  - pretrained_tree_frozen_xfmr
+  - prop_heavy
+  log_interval: 10
+  memory_logging: true

--- a/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_tree_frozen_xfmr_embedding_snli_finetune_config.yaml
+++ b/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_tree_frozen_xfmr_embedding_snli_finetune_config.yaml
@@ -1,0 +1,95 @@
+text_mode: false
+allow_text_files: false
+model:
+  task_type: entailment
+  task_loader_type: aggregative
+  name: pretrained_tree_embedding
+  model_type: embedding
+  freeze:
+    freeze_transformer: true
+  graph:
+    node_feature_dim: 804
+    edge_feature_dim: 70
+    node_state_dim: 1280
+    edge_state_dim: 512
+    hidden_size_multiplier: 2.0
+    edge_hidden_sizes:
+    - 512
+    - 1024
+    node_hidden_sizes:
+    - 1280
+    - 1280
+    graph_rep_dim: 2048
+    graph_transform_sizes:
+    - 1280
+    - 2048
+    edge_net_init_scale: 0.1
+    reverse_dir_param_different: false
+    use_reverse_direction: true
+    share_prop_params: true
+    n_prop_layers: 5
+    pretrained_transformer:
+      model_name: "sentence-transformers/all-MiniLM-L6-v2"
+      max_nodes: 64
+      use_cls_token: false
+      freeze_transformer: true
+      positional_features:
+      - depth
+      - num_siblings
+      - num_children
+      - num_grandparent_children
+      - subtree_size
+      - parent_num_children
+      - distance_to_leaf
+      - nodes_at_level
+      positional_max_values:
+        depth: 15
+        num_siblings: 10
+        num_children: 10
+        num_grandparent_children: 10
+        subtree_size: 40
+        parent_num_children: 10
+        distance_to_leaf: 10
+        nodes_at_level: 20
+  temperature: 0.05
+  aggregation: attention
+  thresh_low: -0.33
+  thresh_high: 0.33
+data:
+  dataset_type: snli
+  batch_size: 256
+  strict_matching: false
+  min_trees_per_group: 1
+  num_workers_train: 0
+  num_workers_val: 0
+  prefetch_factor: 0
+  max_batches_per_epoch: 600
+  contrastive_mode: false
+  allow_negatives: true
+  allow_neutrals: true
+  allow_positives: true
+  num_workers: 0
+embedding_cache_dir: /home/jlunder/research/TMN_DataGen/embedding_cache5/
+use_gpu: false
+train:
+  learning_rate: 5.0e-06
+  pretrained_lr_scale: 0.1
+  weight_decay: 1.0e-05
+  n_epochs: 100
+  patience: 999
+  gradient_accumulation_steps: 1
+  clip_value: 1.0
+  cleanup_interval: 5
+  base_seed: 42
+  reset_epoch_enabled: true
+  checkpoint_save_frequency: 4
+wandb:
+  project: tree-embedding-transformer
+  tags:
+  - finetune
+  - embedding
+  - snli
+  - pretrained_tree_frozen_xfmr
+  - prop_heavy
+  log_interval: 10
+  memory_logging: true

--- a/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_tree_frozen_xfmr_embedding_snli_primary_config.yaml
+++ b/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_tree_frozen_xfmr_embedding_snli_primary_config.yaml
@@ -1,0 +1,99 @@
+text_mode: false
+allow_text_files: false
+model:
+  task_type: infonce
+  task_loader_type: aggregative
+  name: pretrained_tree_embedding
+  model_type: embedding
+  freeze:
+    freeze_transformer: true
+  graph:
+    node_feature_dim: 804
+    edge_feature_dim: 70
+    node_state_dim: 1280
+    edge_state_dim: 512
+    hidden_size_multiplier: 2.0
+    edge_hidden_sizes:
+    - 512
+    - 1024
+    node_hidden_sizes:
+    - 1280
+    - 1280
+    graph_rep_dim: 2048
+    graph_transform_sizes:
+    - 1280
+    - 2048
+    edge_net_init_scale: 0.1
+    reverse_dir_param_different: false
+    use_reverse_direction: true
+    share_prop_params: true
+    n_prop_layers: 5
+    pretrained_transformer:
+      model_name: "sentence-transformers/all-MiniLM-L6-v2"
+      max_nodes: 64
+      use_cls_token: false
+      freeze_transformer: true
+      positional_features:
+      - depth
+      - num_siblings
+      - num_children
+      - num_grandparent_children
+      - subtree_size
+      - parent_num_children
+      - distance_to_leaf
+      - nodes_at_level
+      positional_max_values:
+        depth: 15
+        num_siblings: 10
+        num_children: 10
+        num_grandparent_children: 10
+        subtree_size: 40
+        parent_num_children: 10
+        distance_to_leaf: 10
+        nodes_at_level: 20
+  temperature: 0.05
+  aggregation: attention
+  positive_infonce_weight: 0.55
+  inverse_infonce_weight: 0.3
+  midpoint_infonce_weight: 0.15
+  thresh_low: -0.33
+  thresh_high: 0.33
+data:
+  dataset_type: snli
+  batch_size: 256
+  strict_matching: false
+  min_trees_per_group: 1
+  num_workers_train: 0
+  num_workers_val: 0
+  prefetch_factor: 0
+  max_batches_per_epoch: 600
+  contrastive_mode: false
+  allow_negatives: true
+  allow_neutrals: true
+  allow_positives: true
+  num_workers: 0
+embedding_cache_dir: /home/jlunder/research/TMN_DataGen/embedding_cache5/
+use_gpu: false
+train:
+  learning_rate: 1.0e-05
+  pretrained_lr_scale: 0.1
+  weight_decay: 1.0e-05
+  n_epochs: 100
+  patience: 999
+  gradient_accumulation_steps: 1
+  clip_value: 1.0
+  cleanup_interval: 5
+  base_seed: 42
+  reset_epoch_enabled: true
+  checkpoint_save_frequency: 4
+wandb:
+  project: tree-embedding-transformer
+  tags:
+  - aggregative
+  - embedding
+  - snli
+  - primary
+  - pretrained_tree_frozen_xfmr
+  - prop_heavy
+  log_interval: 10
+  memory_logging: true

--- a/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_tree_frozen_xfmr_matching_contrastive_config.yaml
+++ b/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_tree_frozen_xfmr_matching_contrastive_config.yaml
@@ -1,0 +1,155 @@
+text_mode: false
+allow_text_files: false
+model:
+  task_type: infonce
+  task_loader_type: contrastive
+  name: pretrained_tree_matching
+  model_type: matching
+  freeze:
+    freeze_transformer: true
+  graph:
+    node_feature_dim: 804
+    edge_feature_dim: 70
+    node_state_dim: 1280
+    edge_state_dim: 512
+    hidden_size_multiplier: 2.0
+    edge_hidden_sizes:
+    - 512
+    - 1024
+    node_hidden_sizes:
+    - 1280
+    - 1280
+    graph_rep_dim: 2048
+    graph_transform_sizes:
+    - 1280
+    - 2048
+    edge_net_init_scale: 0.1
+    reverse_dir_param_different: false
+    use_reverse_direction: true
+    share_prop_params: true
+    n_prop_layers: 5
+    pretrained_transformer:
+      model_name: "sentence-transformers/all-MiniLM-L6-v2"
+      max_nodes: 64
+      use_cls_token: false
+      freeze_transformer: true
+      positional_features:
+      - depth
+      - num_siblings
+      - num_children
+      - num_grandparent_children
+      - subtree_size
+      - parent_num_children
+      - distance_to_leaf
+      - nodes_at_level
+      positional_max_values:
+        depth: 15
+        num_siblings: 10
+        num_children: 10
+        num_grandparent_children: 10
+        subtree_size: 40
+        parent_num_children: 10
+        distance_to_leaf: 10
+        nodes_at_level: 20
+  temperature: 0.05
+data:
+  dataset_type: wikiqs
+  dataset_specs:
+  - wikiqs
+  - amazonqa_single/Electronics
+  - amazonqa_single/Baby
+  - amazonqa_multiple/Baby
+  - amazonqa_multiple/Electronics
+  - amazonqa_single/Home_and_Kitchen
+  - amazonqa_single/Industrial_and_Scientific
+  - amazonqa_single/Sports_and_Outdoors
+  - amazonqa_single/Appliances
+  - amazonqa_single/Arts_Crafts_and_Sewing
+  - amazonqa_single/Automotive
+  - amazonqa_single/Beauty
+  - amazonqa_single/Cell_Phones_and_Accessories
+  - amazonqa_single/Clothing_Shoes_and_Jewelry
+  - amazonqa_single/Grocery_and_Gourmet_Food
+  - amazonqa_single/Health_and_Personal_Care
+  - amazonqa_single/Musical_Instruments
+  - amazonqa_single/Office_Products
+  - amazonqa_single/Patio_Lawn_and_Garden
+  - amazonqa_single/Pet_Supplies
+  - amazonqa_single/Software
+  - amazonqa_single/Tools_and_Home_Improvement
+  - amazonqa_single/Toys_and_Games
+  - amazonqa_single/Video_Games
+  - amazonqa_multiple/Home_and_Kitchen
+  - amazonqa_multiple/Industrial_and_Scientific
+  - amazonqa_multiple/Sports_and_Outdoors
+  - amazonqa_multiple/Appliances
+  - amazonqa_multiple/Arts_Crafts_and_Sewing
+  - amazonqa_multiple/Automotive
+  - amazonqa_multiple/Beauty
+  - amazonqa_multiple/Cell_Phones_and_Accessories
+  - amazonqa_multiple/Clothing_Shoes_and_Jewelry
+  - amazonqa_multiple/Grocery_and_Gourmet_Food
+  - amazonqa_multiple/Health_and_Personal_Care
+  - amazonqa_multiple/Musical_Instruments
+  - amazonqa_multiple/Office_Products
+  - amazonqa_multiple/Patio_Lawn_and_Garden
+  - amazonqa_multiple/Pet_Supplies
+  - amazonqa_multiple/Software
+  - amazonqa_multiple/Tools_and_Home_Improvement
+  - amazonqa_multiple/Toys_and_Games
+  - amazonqa_multiple/Video_Games
+  allow_cross_dataset_negatives: false
+  batch_size: 256
+  strict_matching: false
+  pos_pairs_per_anchor: 3
+  neg_pairs_per_anchor: 10
+  min_groups_per_batch: 8
+  anchors_per_group: 1
+  num_workers: 2
+  positive_pairing_ratio: 1.0
+  ensure_positives_in_batch: true
+  prefetch_factor: 2
+  max_batches_per_epoch: 600
+  max_text_chars: 500
+  use_hard_negative_mining: true
+  hard_negative_mining:
+    negative_sampling_mode: ratio_based
+    max_negatives_per_anchor: 10
+    target_neg_to_pos_ratio: 20
+    sampling_strategy: weighted
+    use_structural_filtering: true
+    structural_features:
+    - name: node_count
+      threshold: 0.3
+      weight: 1.0
+      order: 1
+    - name: max_depth
+      threshold: 0.3
+      weight: 0.8
+      order: 2
+    use_semantic_ranking: true
+    semantic_weight: 2.0
+embedding_cache_dir: /home/jlunder/research/TMN_DataGen/embedding_cache5/
+use_gpu: false
+train:
+  learning_rate: 1.0e-05
+  pretrained_lr_scale: 0.1
+  weight_decay: 1.0e-05
+  n_epochs: 50
+  patience: 999
+  gradient_accumulation_steps: 1
+  clip_value: 1.0
+  cleanup_interval: 5
+  base_seed: 42
+  reset_epoch_enabled: true
+  checkpoint_save_frequency: 4
+wandb:
+  project: tree-matching-transformer
+  tags:
+  - contrastive
+  - wikiqs
+  - matching
+  - pretrained_tree_frozen_xfmr
+  - prop_heavy
+  log_interval: 10
+  memory_logging: true

--- a/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_tree_frozen_xfmr_matching_snli_finetune_config.yaml
+++ b/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_tree_frozen_xfmr_matching_snli_finetune_config.yaml
@@ -1,0 +1,95 @@
+text_mode: false
+allow_text_files: false
+model:
+  task_type: entailment
+  task_loader_type: aggregative
+  name: pretrained_tree_matching
+  model_type: matching
+  freeze:
+    freeze_transformer: true
+  graph:
+    node_feature_dim: 804
+    edge_feature_dim: 70
+    node_state_dim: 1280
+    edge_state_dim: 512
+    hidden_size_multiplier: 2.0
+    edge_hidden_sizes:
+    - 512
+    - 1024
+    node_hidden_sizes:
+    - 1280
+    - 1280
+    graph_rep_dim: 2048
+    graph_transform_sizes:
+    - 1280
+    - 2048
+    edge_net_init_scale: 0.1
+    reverse_dir_param_different: false
+    use_reverse_direction: true
+    share_prop_params: true
+    n_prop_layers: 5
+    pretrained_transformer:
+      model_name: "sentence-transformers/all-MiniLM-L6-v2"
+      max_nodes: 64
+      use_cls_token: false
+      freeze_transformer: true
+      positional_features:
+      - depth
+      - num_siblings
+      - num_children
+      - num_grandparent_children
+      - subtree_size
+      - parent_num_children
+      - distance_to_leaf
+      - nodes_at_level
+      positional_max_values:
+        depth: 15
+        num_siblings: 10
+        num_children: 10
+        num_grandparent_children: 10
+        subtree_size: 40
+        parent_num_children: 10
+        distance_to_leaf: 10
+        nodes_at_level: 20
+  temperature: 0.05
+  aggregation: attention
+  thresh_low: -0.33
+  thresh_high: 0.33
+data:
+  dataset_type: snli
+  batch_size: 256
+  strict_matching: false
+  min_trees_per_group: 1
+  num_workers_train: 0
+  num_workers_val: 0
+  prefetch_factor: 0
+  max_batches_per_epoch: 600
+  contrastive_mode: false
+  allow_negatives: true
+  allow_neutrals: true
+  allow_positives: true
+  num_workers: 0
+embedding_cache_dir: /home/jlunder/research/TMN_DataGen/embedding_cache5/
+use_gpu: false
+train:
+  learning_rate: 5.0e-06
+  pretrained_lr_scale: 0.1
+  weight_decay: 1.0e-05
+  n_epochs: 100
+  patience: 999
+  gradient_accumulation_steps: 1
+  clip_value: 1.0
+  cleanup_interval: 5
+  base_seed: 42
+  reset_epoch_enabled: true
+  checkpoint_save_frequency: 4
+wandb:
+  project: tree-matching-transformer
+  tags:
+  - finetune
+  - matching
+  - snli
+  - pretrained_tree_frozen_xfmr
+  - prop_heavy
+  log_interval: 10
+  memory_logging: true

--- a/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_tree_frozen_xfmr_matching_snli_primary_config.yaml
+++ b/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_tree_frozen_xfmr_matching_snli_primary_config.yaml
@@ -1,0 +1,99 @@
+text_mode: false
+allow_text_files: false
+model:
+  task_type: infonce
+  task_loader_type: aggregative
+  name: pretrained_tree_matching
+  model_type: matching
+  freeze:
+    freeze_transformer: true
+  graph:
+    node_feature_dim: 804
+    edge_feature_dim: 70
+    node_state_dim: 1280
+    edge_state_dim: 512
+    hidden_size_multiplier: 2.0
+    edge_hidden_sizes:
+    - 512
+    - 1024
+    node_hidden_sizes:
+    - 1280
+    - 1280
+    graph_rep_dim: 2048
+    graph_transform_sizes:
+    - 1280
+    - 2048
+    edge_net_init_scale: 0.1
+    reverse_dir_param_different: false
+    use_reverse_direction: true
+    share_prop_params: true
+    n_prop_layers: 5
+    pretrained_transformer:
+      model_name: "sentence-transformers/all-MiniLM-L6-v2"
+      max_nodes: 64
+      use_cls_token: false
+      freeze_transformer: true
+      positional_features:
+      - depth
+      - num_siblings
+      - num_children
+      - num_grandparent_children
+      - subtree_size
+      - parent_num_children
+      - distance_to_leaf
+      - nodes_at_level
+      positional_max_values:
+        depth: 15
+        num_siblings: 10
+        num_children: 10
+        num_grandparent_children: 10
+        subtree_size: 40
+        parent_num_children: 10
+        distance_to_leaf: 10
+        nodes_at_level: 20
+  temperature: 0.05
+  aggregation: attention
+  positive_infonce_weight: 0.55
+  inverse_infonce_weight: 0.3
+  midpoint_infonce_weight: 0.15
+  thresh_low: -0.33
+  thresh_high: 0.33
+data:
+  dataset_type: snli
+  batch_size: 256
+  strict_matching: false
+  min_trees_per_group: 1
+  num_workers_train: 0
+  num_workers_val: 0
+  prefetch_factor: 0
+  max_batches_per_epoch: 600
+  contrastive_mode: false
+  allow_negatives: true
+  allow_neutrals: true
+  allow_positives: true
+  num_workers: 0
+embedding_cache_dir: /home/jlunder/research/TMN_DataGen/embedding_cache5/
+use_gpu: false
+train:
+  learning_rate: 1.0e-05
+  pretrained_lr_scale: 0.1
+  weight_decay: 1.0e-05
+  n_epochs: 100
+  patience: 999
+  gradient_accumulation_steps: 1
+  clip_value: 1.0
+  cleanup_interval: 5
+  base_seed: 42
+  reset_epoch_enabled: true
+  checkpoint_save_frequency: 4
+wandb:
+  project: tree-matching-transformer
+  tags:
+  - aggregative
+  - matching
+  - snli
+  - primary
+  - pretrained_tree_frozen_xfmr
+  - prop_heavy
+  log_interval: 10
+  memory_logging: true

--- a/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_tree_matching_contrastive_config.yaml
+++ b/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_tree_matching_contrastive_config.yaml
@@ -1,0 +1,153 @@
+text_mode: false
+allow_text_files: false
+model:
+  task_type: infonce
+  task_loader_type: contrastive
+  name: pretrained_tree_matching
+  model_type: matching
+  graph:
+    node_feature_dim: 804
+    edge_feature_dim: 70
+    node_state_dim: 1280
+    edge_state_dim: 512
+    hidden_size_multiplier: 2.0
+    edge_hidden_sizes:
+    - 512
+    - 1024
+    node_hidden_sizes:
+    - 1280
+    - 1280
+    graph_rep_dim: 2048
+    graph_transform_sizes:
+    - 1280
+    - 2048
+    edge_net_init_scale: 0.1
+    reverse_dir_param_different: false
+    use_reverse_direction: true
+    share_prop_params: true
+    n_prop_layers: 5
+    pretrained_transformer:
+      model_name: "sentence-transformers/all-MiniLM-L6-v2"
+      max_nodes: 64
+      use_cls_token: false
+      freeze_transformer: false
+      positional_features:
+      - depth
+      - num_siblings
+      - num_children
+      - num_grandparent_children
+      - subtree_size
+      - parent_num_children
+      - distance_to_leaf
+      - nodes_at_level
+      positional_max_values:
+        depth: 15
+        num_siblings: 10
+        num_children: 10
+        num_grandparent_children: 10
+        subtree_size: 40
+        parent_num_children: 10
+        distance_to_leaf: 10
+        nodes_at_level: 20
+  temperature: 0.05
+data:
+  dataset_type: wikiqs
+  dataset_specs:
+  - wikiqs
+  - amazonqa_single/Electronics
+  - amazonqa_single/Baby
+  - amazonqa_multiple/Baby
+  - amazonqa_multiple/Electronics
+  - amazonqa_single/Home_and_Kitchen
+  - amazonqa_single/Industrial_and_Scientific
+  - amazonqa_single/Sports_and_Outdoors
+  - amazonqa_single/Appliances
+  - amazonqa_single/Arts_Crafts_and_Sewing
+  - amazonqa_single/Automotive
+  - amazonqa_single/Beauty
+  - amazonqa_single/Cell_Phones_and_Accessories
+  - amazonqa_single/Clothing_Shoes_and_Jewelry
+  - amazonqa_single/Grocery_and_Gourmet_Food
+  - amazonqa_single/Health_and_Personal_Care
+  - amazonqa_single/Musical_Instruments
+  - amazonqa_single/Office_Products
+  - amazonqa_single/Patio_Lawn_and_Garden
+  - amazonqa_single/Pet_Supplies
+  - amazonqa_single/Software
+  - amazonqa_single/Tools_and_Home_Improvement
+  - amazonqa_single/Toys_and_Games
+  - amazonqa_single/Video_Games
+  - amazonqa_multiple/Home_and_Kitchen
+  - amazonqa_multiple/Industrial_and_Scientific
+  - amazonqa_multiple/Sports_and_Outdoors
+  - amazonqa_multiple/Appliances
+  - amazonqa_multiple/Arts_Crafts_and_Sewing
+  - amazonqa_multiple/Automotive
+  - amazonqa_multiple/Beauty
+  - amazonqa_multiple/Cell_Phones_and_Accessories
+  - amazonqa_multiple/Clothing_Shoes_and_Jewelry
+  - amazonqa_multiple/Grocery_and_Gourmet_Food
+  - amazonqa_multiple/Health_and_Personal_Care
+  - amazonqa_multiple/Musical_Instruments
+  - amazonqa_multiple/Office_Products
+  - amazonqa_multiple/Patio_Lawn_and_Garden
+  - amazonqa_multiple/Pet_Supplies
+  - amazonqa_multiple/Software
+  - amazonqa_multiple/Tools_and_Home_Improvement
+  - amazonqa_multiple/Toys_and_Games
+  - amazonqa_multiple/Video_Games
+  allow_cross_dataset_negatives: false
+  batch_size: 256
+  strict_matching: false
+  pos_pairs_per_anchor: 3
+  neg_pairs_per_anchor: 10
+  min_groups_per_batch: 8
+  anchors_per_group: 1
+  num_workers: 2
+  positive_pairing_ratio: 1.0
+  ensure_positives_in_batch: true
+  prefetch_factor: 2
+  max_batches_per_epoch: 600
+  max_text_chars: 500
+  use_hard_negative_mining: true
+  hard_negative_mining:
+    negative_sampling_mode: ratio_based
+    max_negatives_per_anchor: 10
+    target_neg_to_pos_ratio: 20
+    sampling_strategy: weighted
+    use_structural_filtering: true
+    structural_features:
+    - name: node_count
+      threshold: 0.3
+      weight: 1.0
+      order: 1
+    - name: max_depth
+      threshold: 0.3
+      weight: 0.8
+      order: 2
+    use_semantic_ranking: true
+    semantic_weight: 2.0
+embedding_cache_dir: /home/jlunder/research/TMN_DataGen/embedding_cache5/
+use_gpu: false
+train:
+  learning_rate: 1.0e-05
+  pretrained_lr_scale: 0.1
+  weight_decay: 1.0e-05
+  n_epochs: 50
+  patience: 999
+  gradient_accumulation_steps: 1
+  clip_value: 1.0
+  cleanup_interval: 5
+  base_seed: 42
+  reset_epoch_enabled: true
+  checkpoint_save_frequency: 4
+wandb:
+  project: tree-matching-transformer
+  tags:
+  - contrastive
+  - wikiqs
+  - matching
+  - pretrained_tree
+  - prop_heavy
+  log_interval: 10
+  memory_logging: true

--- a/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_tree_matching_snli_finetune_config.yaml
+++ b/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_tree_matching_snli_finetune_config.yaml
@@ -1,0 +1,93 @@
+text_mode: false
+allow_text_files: false
+model:
+  task_type: entailment
+  task_loader_type: aggregative
+  name: pretrained_tree_matching
+  model_type: matching
+  graph:
+    node_feature_dim: 804
+    edge_feature_dim: 70
+    node_state_dim: 1280
+    edge_state_dim: 512
+    hidden_size_multiplier: 2.0
+    edge_hidden_sizes:
+    - 512
+    - 1024
+    node_hidden_sizes:
+    - 1280
+    - 1280
+    graph_rep_dim: 2048
+    graph_transform_sizes:
+    - 1280
+    - 2048
+    edge_net_init_scale: 0.1
+    reverse_dir_param_different: false
+    use_reverse_direction: true
+    share_prop_params: true
+    n_prop_layers: 5
+    pretrained_transformer:
+      model_name: "sentence-transformers/all-MiniLM-L6-v2"
+      max_nodes: 64
+      use_cls_token: false
+      freeze_transformer: false
+      positional_features:
+      - depth
+      - num_siblings
+      - num_children
+      - num_grandparent_children
+      - subtree_size
+      - parent_num_children
+      - distance_to_leaf
+      - nodes_at_level
+      positional_max_values:
+        depth: 15
+        num_siblings: 10
+        num_children: 10
+        num_grandparent_children: 10
+        subtree_size: 40
+        parent_num_children: 10
+        distance_to_leaf: 10
+        nodes_at_level: 20
+  temperature: 0.05
+  aggregation: attention
+  thresh_low: -0.33
+  thresh_high: 0.33
+data:
+  dataset_type: snli
+  batch_size: 256
+  strict_matching: false
+  min_trees_per_group: 1
+  num_workers_train: 0
+  num_workers_val: 0
+  prefetch_factor: 0
+  max_batches_per_epoch: 600
+  contrastive_mode: false
+  allow_negatives: true
+  allow_neutrals: true
+  allow_positives: true
+  num_workers: 0
+embedding_cache_dir: /home/jlunder/research/TMN_DataGen/embedding_cache5/
+use_gpu: false
+train:
+  learning_rate: 5.0e-06
+  pretrained_lr_scale: 0.1
+  weight_decay: 1.0e-05
+  n_epochs: 100
+  patience: 999
+  gradient_accumulation_steps: 1
+  clip_value: 1.0
+  cleanup_interval: 5
+  base_seed: 42
+  reset_epoch_enabled: true
+  checkpoint_save_frequency: 4
+wandb:
+  project: tree-matching-transformer
+  tags:
+  - finetune
+  - matching
+  - snli
+  - pretrained_tree
+  - prop_heavy
+  log_interval: 10
+  memory_logging: true

--- a/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_tree_matching_snli_primary_config.yaml
+++ b/Tree_Matching_Networks/LinguisticTrees/configs/experiment_configs/pretrained_tree_matching_snli_primary_config.yaml
@@ -1,0 +1,97 @@
+text_mode: false
+allow_text_files: false
+model:
+  task_type: infonce
+  task_loader_type: aggregative
+  name: pretrained_tree_matching
+  model_type: matching
+  graph:
+    node_feature_dim: 804
+    edge_feature_dim: 70
+    node_state_dim: 1280
+    edge_state_dim: 512
+    hidden_size_multiplier: 2.0
+    edge_hidden_sizes:
+    - 512
+    - 1024
+    node_hidden_sizes:
+    - 1280
+    - 1280
+    graph_rep_dim: 2048
+    graph_transform_sizes:
+    - 1280
+    - 2048
+    edge_net_init_scale: 0.1
+    reverse_dir_param_different: false
+    use_reverse_direction: true
+    share_prop_params: true
+    n_prop_layers: 5
+    pretrained_transformer:
+      model_name: "sentence-transformers/all-MiniLM-L6-v2"
+      max_nodes: 64
+      use_cls_token: false
+      freeze_transformer: false
+      positional_features:
+      - depth
+      - num_siblings
+      - num_children
+      - num_grandparent_children
+      - subtree_size
+      - parent_num_children
+      - distance_to_leaf
+      - nodes_at_level
+      positional_max_values:
+        depth: 15
+        num_siblings: 10
+        num_children: 10
+        num_grandparent_children: 10
+        subtree_size: 40
+        parent_num_children: 10
+        distance_to_leaf: 10
+        nodes_at_level: 20
+  temperature: 0.05
+  aggregation: attention
+  positive_infonce_weight: 0.55
+  inverse_infonce_weight: 0.3
+  midpoint_infonce_weight: 0.15
+  thresh_low: -0.33
+  thresh_high: 0.33
+data:
+  dataset_type: snli
+  batch_size: 256
+  strict_matching: false
+  min_trees_per_group: 1
+  num_workers_train: 0
+  num_workers_val: 0
+  prefetch_factor: 0
+  max_batches_per_epoch: 600
+  contrastive_mode: false
+  allow_negatives: true
+  allow_neutrals: true
+  allow_positives: true
+  num_workers: 0
+embedding_cache_dir: /home/jlunder/research/TMN_DataGen/embedding_cache5/
+use_gpu: false
+train:
+  learning_rate: 1.0e-05
+  pretrained_lr_scale: 0.1
+  weight_decay: 1.0e-05
+  n_epochs: 100
+  patience: 999
+  gradient_accumulation_steps: 1
+  clip_value: 1.0
+  cleanup_interval: 5
+  base_seed: 42
+  reset_epoch_enabled: true
+  checkpoint_save_frequency: 4
+wandb:
+  project: tree-matching-transformer
+  tags:
+  - aggregative
+  - matching
+  - snli
+  - primary
+  - pretrained_tree
+  - prop_heavy
+  log_interval: 10
+  memory_logging: true


### PR DESCRIPTION
## Summary

- 24 config files for all 5 experimental conditions × embedding/matching:
  - **A** `pretrained_text_*`: HF transformer on text tokens, no GNN (primary + finetune only)
  - **B** `pretrained_noprop_*`: HF transformer on raw 804-dim node features, no GNN
  - **D** `pretrained_tree_*`: GNN (prop_heavy) + HF, both trainable, full pipeline
  - **E** `pretrained_tree_frozen_xfmr_*`: GNN trainable, HF encoder frozen, full pipeline
  - **F** `pretrained_tree_frozen_gnn_*`: GNN frozen from existing checkpoint, HF trainable
- All conditions use `sentence-transformers/all-MiniLM-L6-v2`
- `run_pipeline.sh` updated with new model types and auto-skip logic for conditions A/B/F

## Notes

- `run_pipeline.sh` is outside the repo so those changes are not in this PR but are saved on disk
- Condition F requires `--contrastive-checkpoint` pointing to an existing TTN prop_heavy checkpoint (the frozen GNN weights)
- Integration smoke test (Issue #9) pending current training runs finishing

## Test plan

- [ ] Smoke test: `./run_pipeline.sh pretrained_text_embedding snli "" --primary-batches 5 --finetune-batches 5`
- [ ] Freeze verification for Conditions E and F